### PR TITLE
Grunt 1.x.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,23 +14,21 @@
     }
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-clean": "~0.7.0",
-    "grunt-contrib-copy": "~0.8.0",
-    "grunt-contrib-jshint": "~0.12.0",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt-contrib-watch": "~0.6.1"
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
-  },
-  "dependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "grunt",


### PR DESCRIPTION
Hi Manoj, I pulled these changes from the original repository this was forked from. These changes allow this grunt task to work with grunt 1.x.x. I tested this with our app and the change looks to fix the issue we're having using the task with newer versions of grunt.

Ken